### PR TITLE
Fix yandex-cloud provider version requirements

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     yandex = {
       source  = "yandex-cloud/yandex"
-      version = "= 0.136.0"
+      version = ">= 0.136.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Currently yandex cloud provider is pinned to exact version of provider, making this module impossible to use with modules, that require newer provider versions.